### PR TITLE
Consistent capitalization of language name

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Try Slang
 
-Try slang locally in your browser without downloading or installing anything with [Slang-Playground](/slang-playground).
+Try Slang locally in your browser without downloading or installing anything with [Slang-Playground](/slang-playground).
 
 ## Download Prebuilt Release
 
@@ -24,7 +24,7 @@ Instructions for building Slang from source code are maintained as part of the s
 
 ## Your First Slang Shader
 
-Follow [this tutorial](/docs/first-slang-shader) on how to write your first slang shader and compile it for execution with the Vulkan API.
+Follow [this tutorial](/docs/first-slang-shader) on how to write your first Slang shader and compile it for execution with the Vulkan API.
 
 ## The User-Guide
 


### PR DESCRIPTION
Capitalization helps distinguish the language name from the common noun "slang". The home page always capitalizes the S, fix the few remaining instances without in the `Getting Started` page.