### PR TITLE
Remove extra TOC entries by turning H1 headings into H2

### DIFF
--- a/docs/coming-from-glsl.md
+++ b/docs/coming-from-glsl.md
@@ -7,14 +7,14 @@ intro_image_absolute: true
 intro_image_hide_on_mobile: false
 ---
 
-# Overview
+## Overview
 This guide provides a reference for migrating GLSL shaders to Slang.
 
-# Type and Syntax Reference
+## Type and Syntax Reference
 
 When converting GLSL shaders to Slang, you'll need to translate GLSL types and syntax to their Slang equivalents.
 
-## Scalar Types
+### Scalar Types
 
 | GLSL Type | Slang Type | Description |
 |-----------|------------|-------------|
@@ -31,7 +31,7 @@ When converting GLSL shaders to Slang, you'll need to translate GLSL types and s
 | `int64_t` | `int64_t`  | 64-bit signed integer |
 | `uint64_t`| `uint64_t` | 64-bit unsigned integer |
 
-## Vector Types
+### Vector Types
 
 | GLSL Type | Slang Type | Description |
 |-----------|------------|-------------|
@@ -54,7 +54,7 @@ When converting GLSL shaders to Slang, you'll need to translate GLSL types and s
 | `dvec3`   | `double3`  | 3-component double vector |
 | `dvec4`   | `double4`  | 4-component double vector |
 
-## Matrix Types
+### Matrix Types
 
 | GLSL Type | Slang Type | Description |
 |-----------|------------|-------------|
@@ -77,7 +77,7 @@ When converting GLSL shaders to Slang, you'll need to translate GLSL types and s
 | `f16mat4x2` | `half4x2` | 4×2 half-precision float matrix |
 | `f16mat4x3` | `half4x3` | 4×3 half-precision float matrix |
 
-## Vector/Matrix Construction
+### Vector/Matrix Construction
 
 GLSL:
 
@@ -103,7 +103,7 @@ float4x4 transform = float4x4(
 );
 ```
 
-## Matrix Operations
+### Matrix Operations
 
 GLSL:
 
@@ -133,7 +133,7 @@ float4 transformed = mul(a, v);  // matrix * column vector
 
 Note: Slang uses the `mul()` function for matrix multiplication rather than the `*` operator. Also, vectors are treated as column vectors in Slang, while they're treated as row vectors in GLSL, so the order of arguments is inverted.
 
-## Shader Inputs and Outputs
+### Shader Inputs and Outputs
 
 GLSL and Slang handle shader inputs and outputs differently. Here's a fragment/pixel shader example:
 
@@ -187,11 +187,11 @@ float4 main(float2 texCoord : TEXCOORD0) : SV_Target0 {
 
 Both Slang methods produce the same result, but Method 1 is more organized for complex shaders with many inputs and outputs, while Method 2 is more concise for simple shaders.
 
-## Built-in Variables
+### Built-in Variables
 
 GLSL provides built-in variables that can be accessed directly in shaders, while Slang requires these variables to be explicitly declared as inputs or outputs in shader entry point functions. Unlike regular shader inputs and outputs which you define yourself, built-in variables provide access to system values like vertex IDs, screen positions, etc.
 
-### Example: Minimal Vertex Shader with Built-in Variables
+#### Example: Minimal Vertex Shader with Built-in Variables
 
 Here's a simplified example showing how built-in variables work in both GLSL and Slang:
 
@@ -236,7 +236,7 @@ Notice the key differences:
 
 For more complex shaders, you can use structures for inputs and outputs as shown in the previous section.
 
-### Built-in Variables Reference
+#### Built-in Variables Reference
 
 The following table maps GLSL built-in variables to their corresponding Slang system value semantics across standard shader stages. In GLSL, these variables are accessed directly as globals, while in Slang they must be declared explicitly in function signatures with appropriate semantic annotations.
 
@@ -277,7 +277,7 @@ The following table maps GLSL built-in variables to their corresponding Slang sy
 | `gl_ViewportIndex` | `SV_ViewportArrayIndex` |
 | `gl_WorkGroupID` | `SV_GroupID` |
 
-### Ray Tracing Built-ins
+#### Ray Tracing Built-ins
 
 Ray tracing built-ins in Slang are accessed through function calls rather than system value semantics. The following table maps GLSL ray tracing built-ins to their corresponding Slang functions:
 
@@ -296,11 +296,11 @@ Ray tracing built-ins in Slang are accessed through function calls rather than s
 | `gl_WorldRayDirectionEXT` | `WorldRayDirection()` |
 | `gl_WorldRayOriginEXT` | `WorldRayOrigin()` |
 
-## Built-in Functions and Operators
+### Built-in Functions and Operators
 
 When porting GLSL shaders to Slang, most common mathematical functions (sin, cos, tan, pow, sqrt, abs, etc.) share identical names in both languages. However, there are several important differences to be aware of, listed below:
 
-### Key Function Differences
+#### Key Function Differences
 
 | GLSL | Slang | Description |
 |------|-------|-------------|
@@ -313,31 +313,31 @@ When porting GLSL shaders to Slang, most common mathematical functions (sin, cos
 | `m1 * m2` (matrix multiply) | `mul(m1, m2)` | Matrix multiplication |
 | `v * m` (row vector) | `mul(m, v)` (column vector) | Vector-matrix multiplication |
 
-# Resource Handling
+## Resource Handling
 
 This section covers how to convert GLSL resource declarations to Slang, including different buffer types, textures, and specialized resources.
 
-## Resource Binding Models
+### Resource Binding Models
 
 Slang supports three different binding syntax options to accommodate both HLSL-style and GLSL-style resource declarations:
 
-### GLSL Binding Model
+#### GLSL Binding Model
 
 ```glsl
 // GLSL uses binding and set numbers
 layout(binding = 0, set = 0) uniform UniformBufferA { ... };
 ```
 
-### Slang Binding Models
+#### Slang Binding Models
 
-#### Option 1: HLSL Register Syntax
+##### Option 1: HLSL Register Syntax
 
 ```hlsl
 // Using register semantics with space (equivalent to set)
 ConstantBuffer<UniformBufferA> bufferA : register(b0, space0);
 ```
 
-#### Option 2: GLSL-style Layout Syntax
+##### Option 2: GLSL-style Layout Syntax
 
 ```hlsl
 // Using GLSL-style binding with [[vk::binding(binding, set)]]
@@ -345,7 +345,7 @@ ConstantBuffer<UniformBufferA> bufferA : register(b0, space0);
 ConstantBuffer<UniformBufferA> bufferA;
 ```
 
-#### Option 3: Direct GLSL Layout Syntax
+##### Option 3: Direct GLSL Layout Syntax
 
 ```hlsl
 // Using layout syntax identical to GLSL
@@ -354,7 +354,7 @@ layout(binding = 0, set = 0) ConstantBuffer<UniformBufferA> bufferA;
 
 All binding syntax options work the same way for all resource types (ConstantBuffer, Texture2D, RWStructuredBuffer, etc.). The GLSL-style options (2 and 3) can be particularly helpful when porting GLSL shaders without changing the binding model.
 
-## Buffer Types
+### Buffer Types
 
 | Resource Type | GLSL | Slang | Description |
 |---------------|------|-------|-------------|
@@ -412,11 +412,11 @@ Key differences to note:
 2. In Slang, structured buffers must be indexed even for a single element (e.g., `data[0].value`)
 3. In Slang, all buffer members are accessed through the buffer variable name (e.g., `params.scale`, `data[0].value`)
 
-## Texture Resources
+### Texture Resources
 
 This section covers the declaration and usage of texture resources in Slang compared to GLSL.
 
-### Combined Texture Samplers
+#### Combined Texture Samplers
 
 GLSL:
 ```glsl
@@ -471,7 +471,7 @@ float4 main(float4 position : SV_Position) : SV_Target0 {
 | `textureGather(sampler, coord)` | `sampler.Gather(coord)` | Gather four texels |
 | `textureGatherOffset(sampler, coord, offset)` | `sampler.GatherOffset(coord, offset)` | Gather with offset |
 
-### Separate Texture Samplers
+#### Separate Texture Samplers
 
 GLSL:
 ```glsl
@@ -501,7 +501,7 @@ float4 main(float4 position : SV_Position) : SV_Target {
 }
 ```
 
-## Image Resources
+### Image Resources
 
 This section covers the declaration and usage of image resources in Slang compared to GLSL, including how to perform image load/store operations.
 
@@ -556,13 +556,13 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID) {
 | `imageStore(image, coord, value)` | `image[coord] = value` or `image.Store(coord, value)` | Write to image |
 | `imageSize(image)` | `image.GetDimensions(width, height)` | Get image dimensions |
 
-# Shader Entry Point Syntax
+## Shader Entry Point Syntax
 
 GLSL and Slang use fundamentally different approaches for shader entry points. While GLSL always uses a `void main()` function with implicit inputs/outputs through global variables, Slang uses explicitly typed entry points with decorators and function parameters/return values.
 
 This section provides a general overview of the entry point pattern differences. Detailed shader stage-specific conversion information will be covered in a later section.
 
-## Core Entry Point Pattern
+### Core Entry Point Pattern
 
 **GLSL Pattern:**
 ```glsl
@@ -593,7 +593,7 @@ return_type main(parameter_type param : semantic) : return_semantic {
 }
 ```
 
-## Shader Stage Decorators
+### Shader Stage Decorators
 
 | Shader Stage | Slang Decoration |
 |--------------|------------------|
@@ -614,13 +614,13 @@ return_type main(parameter_type param : semantic) : return_semantic {
 
 Note: For detailed conversions of specific shader stages including tessellation, geometry, mesh, and ray tracing shaders, see the "Shader Stage-Specific Conversions" section later in this guide.
 
-# Shader Stage-Specific Conversions
+## Shader Stage-Specific Conversions
 
 This section provides mappings for each shader stage from GLSL to Slang, focusing on essential declarations, attributes, and stage-specific functionality.
 
-## Vertex Shaders
+### Vertex Shaders
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -638,13 +638,13 @@ float4 main(float3 position : POSITION) : SV_Position {
 }
 ```
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Add `[shader("vertex")]` decoration
 
-## Fragment/Pixel Shaders
+### Fragment/Pixel Shaders
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -669,15 +669,15 @@ float4 main(float4 position : SV_Position) : SV_Target0 {
 }
 ```
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Add `[shader("pixel")]` decoration
 - **Early Z testing**: Use `[earlydepthstencil]` attribute
 - **Multiple outputs**: Use a struct with multiple fields with `SV_Target0/1/2` semantics
 
-## Compute Shaders
+### Compute Shaders
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -696,15 +696,15 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID) {
 }
 ```
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Thread group size**: Replace `layout(local_size_x=X...) in` with `[numthreads(X,Y,Z)]`
 - **Shared memory**: Replace `shared` with `groupshared`
 - **Barriers**: Replace `barrier()` with `GroupMemoryBarrierWithGroupSync()`
 
-## Hull Shader (Tessellation Control)
+### Hull Shader (Tessellation Control)
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -742,7 +742,7 @@ PatchTessFactors PatchConstantFunction(InputPatch<Vertex, 3> patch) {
 }
 ```
 
-### Key Attribute Mappings
+#### Key Attribute Mappings
 
 | GLSL | Slang | Description |
 |------|-------|-------------|
@@ -752,16 +752,16 @@ PatchTessFactors PatchConstantFunction(InputPatch<Vertex, 3> patch) {
 | *Implicit* | `[outputtopology("triangle_cw/triangle_ccw/line")]` | Output topology |
 | *N/A* | `[patchconstantfunc("FunctionName")]` | Function for tessellation factors |
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Split structure**: Separate the per-control-point calculations from patch-constant calculations
 - **Explicit domain/partitioning**: Add required attributes that are implicit in GLSL
 - **Patch constants**: Create separate function decorated with `[patchconstantfunc]`
 - **Input/Output patches**: Use `InputPatch<T, N>` and return individual control points
 
-## Domain Shader (Tessellation Evaluation)
+### Domain Shader (Tessellation Evaluation)
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -788,7 +788,7 @@ float4 main(
 }
 ```
 
-### Key Attribute Mappings
+#### Key Attribute Mappings
 
 | GLSL | Slang | Description |
 |------|-------|-------------|
@@ -796,16 +796,16 @@ float4 main(
 | `layout(equal_spacing) in` | *Set in hull shader* | Tessellation spacing |
 | `layout(ccw) in` | *Set in hull shader* | Winding order |
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Domain specification**: Use `[domain("tri/quad/isoline")]` attribute
 - **Tessellation coordinates**: Access via `SV_DomainLocation` parameter
 - **Control points**: Access via `OutputPatch<T, N>` parameter
 - **Patch constants**: Access via a patch constant struct parameter
 
-## Geometry Shader
+### Geometry Shader
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -834,7 +834,7 @@ void main(
 }
 ```
 
-### Key Attribute Mappings
+#### Key Attribute Mappings
 
 | GLSL | Slang | Description |
 |------|-------|-------------|
@@ -842,7 +842,7 @@ void main(
 | `layout(points/line_strip/triangle_strip) out` | Output stream type | Output primitive type |
 | `layout(max_vertices = N) out` | `[maxvertexcount(N)]` | Maximum output vertices |
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Add `[shader("geometry")]` and `[maxvertexcount(N)]`
 - **Input primitives**: Use primitive type prefix on input array parameter
@@ -850,9 +850,9 @@ void main(
 - **Vertex emission**: Replace `EmitVertex()` with `outputStream.Append(v)`
 - **End primitive**: Replace `EndPrimitive()` with `outputStream.RestartStrip()`
 
-## Amplification Shader (Task Shader)
+### Amplification Shader (Task Shader)
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -881,16 +881,16 @@ void main(
 }
 ```
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Add `[shader("amplification")]` and `[numthreads(X,Y,Z)]` decorations
 - **Payload**: Replace `taskPayloadSharedEXT` with output parameter
 - **Dispatch**: Replace `EmitMeshTasksEXT` with `DispatchMesh`
 - **Thread IDs**: Access thread IDs through function parameters with semantics
 
-## Mesh Shader
+### Mesh Shader
 
-### Core Declaration Mapping
+#### Core Declaration Mapping
 
 **GLSL:**
 ```glsl
@@ -928,7 +928,7 @@ void main(
 }
 ```
 
-### Key Attribute Mappings
+#### Key Attribute Mappings
 
 | GLSL | Slang | Description |
 |------|-------|-------------|
@@ -936,7 +936,7 @@ void main(
 | `layout(triangles) out` | `[outputtopology("triangle")]` | Output primitive type |
 | `layout(max_vertices = N, max_primitives = M) out` | Output parameters | Maximum vertices/primitives |
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Add `[shader("mesh")]` and `[numthreads(X,Y,Z)]` decorations
 - **Output topology**: Use `[outputtopology("triangle")]` attribute
@@ -944,9 +944,9 @@ void main(
 - **Vertex access**: Replace `gl_MeshVerticesEXT[idx]` with `verts[idx]`
 - **Primitive access**: Replace `gl_PrimitiveTriangleIndicesEXT[idx]` with `prims[idx]`
 
-## Ray Tracing Shaders
+### Ray Tracing Shaders
 
-### Ray Generation Shader
+#### Ray Generation Shader
 
 **GLSL:**
 ```glsl
@@ -975,7 +975,7 @@ void main() {
 }
 ```
 
-### Closest Hit Shader
+#### Closest Hit Shader
 
 **GLSL:**
 ```glsl
@@ -998,7 +998,7 @@ void main(inout PayloadData payload, in BuiltInTriangleIntersectionAttributes at
 }
 ```
 
-### Miss Shader
+#### Miss Shader
 
 **GLSL:**
 ```glsl
@@ -1021,7 +1021,7 @@ void main(inout PayloadData payload) {
 }
 ```
 
-### Key Conversion Points
+#### Key Conversion Points
 
 - **Declaration**: Use appropriate decorator for each shader type
 - **Ray payload**: Pass as `inout` parameter instead of global variable

--- a/docs/compilation-api.md
+++ b/docs/compilation-api.md
@@ -7,8 +7,7 @@ intro_image_absolute: true
 intro_image_hide_on_mobile: false
 ---
 
-Using the Slang Compilation API
-===============================
+## Using the Slang Compilation API
 
 This tutorial explains the flow of calls needed to use the Slang Compilation API. The overall sequence is described in [Basic Compilation](#basic-compilation) followed by a discussion on more advanced topics.
 
@@ -16,8 +15,7 @@ Using the compilation API offers much more control over compilation compared to 
 
 The Slang compilation API is provided as a dynamic library. Linking to it, you have access to the compilation API which is organized in a Component Object Model (COM) fashion.  The Slang [User Guide](https://shader-slang.com/slang/user-guide/compiling.html#using-the-compilation-api) describes Slang's "COM-lite" interface a bit more.
 
-Table of Contents
-=================
+## Table of Contents
 
 * [Basic Compilation](#basic-compilation)
 * [Precompiled Modules](#precompiled-modules)
@@ -28,8 +26,7 @@ Table of Contents
 * [Post-Compilation Reflection](#post-compilation-reflection)
 * [Complete Example](#complete-example)
 
-Basic Compilation
------------------
+### Basic Compilation
 
 This is the overall flow needed to compile even the simplest applications.
 
@@ -41,8 +38,8 @@ This is the overall flow needed to compile even the simplest applications.
 6. [Link Program](#link)
 7. [Get Target Kernel Code](#get-target-kernel-code)
 
-## Step-by-step
-### Includes
+### Step-by-step
+#### Includes
 The main header file is `slang.h`, though you also need `slang-com-ptr.h` to have the definition of Slang::ComPtr used throughout the API. `slang-com-helper.h` is nice to have, since it provides helpers for checking API return values and otherwise using COM.
 ```cpp
 #include "slang.h"
@@ -50,7 +47,7 @@ The main header file is `slang.h`, though you also need `slang-com-ptr.h` to hav
 #include "slang-com-helper.h"
 ```
 
-### Create Global Session
+#### Create Global Session
 The global API call to `createGlobalSession` is always going to be the first runtime step, since it establishes a connection to the Slang API implementation.
 
 ```cpp
@@ -58,7 +55,7 @@ The global API call to `createGlobalSession` is always going to be the first run
     createGlobalSession(globalSession.writeRef());
 ```
 
-### Create Session
+#### Create Session
 To read more about what sessions are all about, see [About Sessions](#about-sessions).
 Creating a session sets the configuration for what you are going to do with the API.
 
@@ -72,7 +69,7 @@ The `SessionDesc` object holds all the configuration for the Session.
     slang::SessionDesc sessionDesc = {};
 ```
 
-#### List of enabled compilation targets
+##### List of enabled compilation targets
 
 Here, only one target is enabled, `spirv_1_5`. You can enable more targets, for example, if you need to be able to compile the same source to DXIL as well as SPIRV.
 ```cpp
@@ -84,7 +81,7 @@ Here, only one target is enabled, `spirv_1_5`. You can enable more targets, for 
     sessionDesc.targetCount = 1;
 ```
 
-#### Preprocessor defines
+##### Preprocessor defines
 
 Slang supports using the preprocessor.
 ```cpp
@@ -97,7 +94,7 @@ Slang supports using the preprocessor.
     sessionDesc.preprocessorMacroCount = preprocessorMacroDesc.size();
 ```
 
-#### Compiler options
+##### Compiler options
 
 Here is where you can specify Session-wide options. Check the [User Guide](https://shader-slang.com/slang/user-guide/compiling.html#compiler-options) for info on available options.
 
@@ -113,7 +110,7 @@ Here is where you can specify Session-wide options. Check the [User Guide](https
     sessionDesc.compilerOptionEntryCount = options.size();
 ```
 
-#### Create the session
+##### Create the session
 
 With a fully populated `SessionDesc`, the session can be created.
 
@@ -122,7 +119,7 @@ With a fully populated `SessionDesc`, the session can be created.
     globalSession->createSession(sessionDesc, session.writeRef());
 ```
 
-### Load Modules
+#### Load Modules
 
 Modules are the granularity of shader source code that can be compiled in Slang. When using the compilation API, there are two main functions to consider.
 
@@ -145,11 +142,11 @@ Modules are the granularity of shader source code that can be compiled in Slang.
     }
 ```
 
-#### Life Time of Modules
+##### Life Time of Modules
 
 Modules are owned by the slang Session. Once loaded, they are valid as long as the Session is valid.
 
-### Query Entry Points
+#### Query Entry Points
 
 Slang shaders may contain many entry points, and it's necessary to be able to identify them programatically in the Compilation API in order to select which entry points to compile.
 
@@ -173,7 +170,7 @@ A common way to query an entry-point is by using the `IModule::findEntryPointByN
 It is also possible to query entry-points by index, and work backwards to check the name of the entry-points that are returned at different indices.
 Check the [User Guide](https://shader-slang.com/slang/user-guide/reflection.html#program-reflection) for info.
 
-### Compose Modules and Entry Points
+#### Compose Modules and Entry Points
 
 Up to this point, modules have been loaded, and entry points have been identified, but to move forward with defining a GPU program, the relevant subset need to be selected for _composition_ into a unified program.
 
@@ -197,7 +194,7 @@ Up to this point, modules have been loaded, and entry points have been identifie
     }
 ```
 
-### Link
+#### Link
 
 Ensure that there are no missing dependencies in the composed program by using `link()`.
 
@@ -213,7 +210,7 @@ Ensure that there are no missing dependencies in the composed program by using `
     }
 ```
 
-### Get Target Kernel Code
+#### Get Target Kernel Code
 
 Finally, it's time to compile the linked Slang program to the target format.
 
@@ -269,7 +266,7 @@ Both methods cache results within the session and will return a pre-compiled blo
 About Sessions
 --------------
 
-### What's a session?
+#### What's a session?
 
 A session is a scope for caching and reuse. As you use the Slang API, the session caches everything that is loaded in it.
 
@@ -281,7 +278,7 @@ It's strongly recommended to use as few session objects as possible in applicati
 
 Using long-lived sessions with Slang API is a big advantage over compiling with the standalone `slangc` compiler executable, since each invocation of `slangc` creates a new session object by necessity.
 
-### When do I need a new Session?
+#### When do I need a new Session?
 
 A session does have some global state in it which currently makes it unable to cache and reuse artifacts, namely, the `#define` configurations. Unique combinations of preprocessor `#defines` used in your shaders will require unique session objects.
 
@@ -299,16 +296,16 @@ API methods for module precompilation are described in the [User Guide](https://
 Specialization
 --------------
 
-### Link-time Constants
+#### Link-time Constants
 
 This form of specialization involves placing relevant constant definitions in a separate Module that can be selectively included. For example, if you have two variants of a shader that differ in constants that they use, you can create two different Modules for the constants, one for each variant. When composing one variant or the other, just select the right constants module in createCompositeComponentType(). This is described also in the [User Guide](https://shader-slang.com/slang/user-guide/link-time-specialization.html#link-time-constants)
 
-### Link-time Types
+#### Link-time Types
 
 Similar to Link-time Constants. This form of specialization simply puts different versions of user types in separate modules so that the needed implementation can be selected when creating the CompositeComponentType.
 [User Guide](https://shader-slang.com/slang/user-guide/link-time-specialization.html#link-time-types)
 
-### Generics Specialization
+#### Generics Specialization
 
 Say you have a shader that has a feature in it that can be in one of two states, "High Quality" and "Low Quality". One way to support both modes of operation is to use generics. Put the logic for the two modes into two structs, both conforming to an interface (e.g. `IQuality`) that can be consistently used by callers.
 
@@ -572,7 +569,7 @@ void computeMain(uint3 threadId_0 : SV_DispatchThreadID)
 
 Notice in particular the switch case added in the function `float U_S11specialized8IQuality8getValuep0pf_0(uint2 _S1)`.
 
-### Supporting both specialization and dynamic dispatch
+#### Supporting both specialization and dynamic dispatch
 
 In the prior example, `HighQuality` and `LowQuality` are both supported in a single uber-shader, compiled to support dynamic dispatch on the call to `getValue()`. To achieve this, two `ITypeConformance` objects were added to the composite component.
 
@@ -816,7 +813,7 @@ int main()
 }
 ```
 
-### Compile it (g++ directions)
+#### Compile it (g++ directions)
 * Assumes Slang is installed in the current directory at `slang`.
 * Assumes program is saved to "shortest.cpp".
 * Assumes a release build of Slang.
@@ -827,7 +824,7 @@ If any of the above assumptions are wrong in your case, adjust the paths below t
 g++ -I./slang/include --std=c++14 shortest.cpp -L./slang/build/Release/lib/ -l:libslang.so
 ```
 
-### Run it
+#### Run it
 
 ```bat
 LD_LIBRARY_PATH=slang/build/Release/lib ./a.out

--- a/docs/understanding-generics.md
+++ b/docs/understanding-generics.md
@@ -7,9 +7,9 @@ intro_image_absolute: true
 intro_image_hide_on_mobile: false
 ---
 
-# Understanding Slang Generics
+## Understanding Slang Generics
 
-## Introduction
+### Introduction
 
 When writing shader code, we often need to write similar logic that works with
 different types. For example, we might have different kinds of lights in our
@@ -23,7 +23,7 @@ be verified at the definition site rather than when the code is used. This
 leads to clearer error messages and faster compilation times, as the compiler
 doesn't need to repeatedly verify the same code for each use case.
 
-## Generics, Traits, and Type Classes
+### Generics, Traits, and Type Classes
 
 Slang's generics system shares similarities with several modern programming
 language features: Swift's protocols, Rust's traits, and Haskell's type
@@ -37,7 +37,7 @@ capabilities." This distinction leads to more flexible and composable code, as
 types can implement multiple interfaces without the complexity of multiple
 inheritance.
 
-## A Motivating Example
+### A Motivating Example
 
 Let's start with a common scenario in graphics programming - implementing
 different types of lights:
@@ -132,7 +132,7 @@ In short, overloaded functions can only be used when the types are fully known
 at the call site. Overloading can also obscure the programmer's intentions,
 giving poorer error messages and code understandability.
 
-### Here's how we can improve this with generics and interfaces:
+#### Here's how we can improve this with generics and interfaces:
 
 We can define an interface, to which lights must conform.
 
@@ -244,7 +244,7 @@ This generic solution provides several benefits:
   objects which aren't light will tell the programmer exactly that, rather than
   some error message within the implementation of `cullLights`
 
-## Performance and Compilation
+### Performance and Compilation
 
 Like Rust traits and C++ templates, Slang's generics are completely resolved at
 compile time through a process called monomorphization ([except when using existential types](https://github.com/shader-slang/slang/blob/master/docs/design/existential-types.md)). This means that for
@@ -266,7 +266,7 @@ specialized for `PointLight` and one for `SpotLight`. This results in:
 - Full optimization opportunities for each specific type
 - Larger binary size when many specializations are needed
 
-## From C++ Templates to Slang Generics
+### From C++ Templates to Slang Generics
 
 While C++ templates and Slang generics can solve similar problems, their
 approaches differ significantly. The lighting example, for example:
@@ -330,7 +330,7 @@ interface.
 float addValue<T>(T v0, T v1) where T : IArithmetic { return v0 + v1; }
 ```
 
-## Generic programming over Scalars and Vectors
+### Generic programming over Scalars and Vectors
 
 It is still possible to write functions which can generically operate over
 scalars and vectors, for example using the
@@ -339,9 +339,9 @@ or
 [`IFloat`](https://shader-slang.com/stdlib-reference/interfaces/ifloat-01/index.html)
 interfaces.
 
-## Advanced Generic Features
+### Advanced Generic Features
 
-### Associated Types
+#### Associated Types
 
 Sometimes we need to work with types that are related to our generic parameter.
 For example, different lights might use different parameter types, which we
@@ -372,7 +372,7 @@ struct SpotLight : ILight
 }
 ```
 
-### Generic Value Parameters
+#### Generic Value Parameters
 
 Sometimes we need to parameterize by compile-time values, for example
 abstracting over a compile-time integer is shown here:
@@ -392,7 +392,7 @@ struct LightArray<T, let N : int> where T : ILight
 }
 ```
 
-## Further Reading
+### Further Reading
 
 - [Interfaces in Slang](https://github.com/shader-slang/slang/blob/master/docs/design/interfaces.md)
 - [Existential types in Slang](https://github.com/shader-slang/slang/blob/master/docs/design/existential-types.md) 


### PR DESCRIPTION
Fixes #73

readthedocs treats H1 headings as document titles in the sidebar.
This change turns all extra H1 headings into H2, H2 to H3, etc.

See the Tutorials section at the bottom of the left-hand side bar on the [site built from main](
https://slang-documentation.readthedocs.io/en/latest/) for the extraneous titles.
See https://shader-slanggithubio-aidanfnv-wip.readthedocs.io/en/fix-readthedocs-headings/ for what the site looks like on this branch.