### PR TITLE
Add stable branch syncing and webhook for readthedocs build triggering

### DIFF
--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -1,0 +1,76 @@
+name: Sync Stable Branch with Main
+
+on:
+  schedule:
+    # Run at 3:00 AM UTC every day
+    - cron: '0 3 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  sync-stable-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main # Explicitly checkout main
+          # Fetch all history for all branches and tags
+          fetch-depth: 0
+          # Get submodules, but don't update them yet
+          submodules: 'recursive'
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Get latest slang release tag
+        id: slang_latest_tag
+        run: |
+          LATEST_TAG=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/shader-slang/slang/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$LATEST_TAG" ]; then
+            echo "Failed to fetch latest slang release tag"
+            exit 1
+          fi
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Fetched latest slang tag: $LATEST_TAG"
+
+      - name: Update slang submodule to latest release tag
+        run: |
+          cd docs/external/slang
+          git fetch --tags origin
+          git checkout ${{ steps.slang_latest_tag.outputs.tag }}
+          cd ../../.. # Back to repo root
+          echo "Checked out tag ${{ steps.slang_latest_tag.outputs.tag }} in docs/external/slang"
+
+      - name: Update other submodules
+        run: |
+          git submodule update --remote --recursive docs/external/slangpy docs/external/stdlib-reference
+          echo "Updated other submodules (slangpy, stdlib-reference)"
+
+      - name: Check if submodules changed
+        id: check_changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes to stable branch
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git commit -m "Sync stable: Update submodules (slang@${{ steps.slang_latest_tag.outputs.tag }})"
+          # Force push the current HEAD (main + submodule updates) to stable
+          git push origin HEAD:stable --force
+
+      - name: Trigger Read the Docs Build on stable branch update
+        if: steps.check_changes.outputs.changes == 'true'
+        env:
+          RTD_WEBHOOK_SECRET: ${{ secrets.RTD_WEBHOOK_SECRET }}
+        run: |
+          curl -X POST \
+               -H "Authorization: token $RTD_WEBHOOK_SECRET" \
+               https://readthedocs.org/api/v2/webhook/shader-slanggithubio-aidanfnv-wip/295699/

--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'Read the Docs Bot'
+          git config --global user.email 'rtd-bot@shader-slang.com'
 
       - name: Get latest slang release tag
         id: slang_latest_tag

--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -28,10 +28,12 @@ jobs:
 
       - name: Get latest slang release tag
         id: slang_latest_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Provide token explicitly for gh
         run: |
-          LATEST_TAG=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/shader-slang/slang/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          LATEST_TAG=$(gh release view --repo shader-slang/slang --json tagName --jq .tagName)
           if [ -z "$LATEST_TAG" ]; then
-            echo "Failed to fetch latest slang release tag"
+            echo "Failed to fetch latest slang release tag using gh"
             exit 1
           fi
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
@@ -45,28 +47,28 @@ jobs:
           popd
           echo "Checked out tag ${{ steps.slang_latest_tag.outputs.tag }} in docs/external/slang"
 
-      - name: Update other submodules
-        run: |
-          git submodule update --remote --recursive docs/external/slangpy docs/external/stdlib-reference
-          echo "Updated other submodules (slangpy, stdlib-reference)"
-
       - name: Check for changes
         id: check_changes
         run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
+          # Only stage the slang submodule, as the others are already updated
+          git add docs/external/slang
+          
+          # Check if the index differs from HEAD
+          # git diff --cached --quiet exits 0 if no diff, 1 if diff
+          if ! git diff --cached --quiet; then
+            echo "Changes detected in submodule references."
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected."
           else
+            echo "No changes detected in submodule references."
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected."
+            # If no changes, reset the index in case unrelated changes were staged
+            git reset HEAD --quiet
           fi
 
       - name: Commit and push changes to stable branch
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          # Explicitly stage the updated submodule references
-          git add docs/external/slang docs/external/slangpy docs/external/stdlib-reference
-          git commit -m "Sync stable: Update submodules (slang@${{ steps.slang_latest_tag.outputs.tag }})"
+          git commit -m "Sync stable to release (slang@${{ steps.slang_latest_tag.outputs.tag }})"
           git push origin HEAD:stable --force
           echo "Committed and force-pushed updates to stable branch."
 

--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -1,4 +1,4 @@
-name: Sync Stable Branch with Main
+name: Sync Stable Branch with Slang Release
 
 on:
   schedule:

--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -39,10 +39,10 @@ jobs:
 
       - name: Update slang submodule to latest release tag
         run: |
-          cd docs/external/slang
+          pushd docs/external/slang
           git fetch --tags origin
           git checkout ${{ steps.slang_latest_tag.outputs.tag }}
-          cd ../../.. # Back to repo root
+          popd
           echo "Checked out tag ${{ steps.slang_latest_tag.outputs.tag }} in docs/external/slang"
 
       - name: Update other submodules
@@ -53,7 +53,6 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          git add -A
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected."
@@ -65,7 +64,8 @@ jobs:
       - name: Commit and push changes to stable branch
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          git add -A
+          # Explicitly stage the updated submodule references
+          git add docs/external/slang docs/external/slangpy docs/external/stdlib-reference
           git commit -m "Sync stable: Update submodules (slang@${{ steps.slang_latest_tag.outputs.tag }})"
           git push origin HEAD:stable --force
           echo "Committed and force-pushed updates to stable branch."

--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -50,21 +50,25 @@ jobs:
           git submodule update --remote --recursive docs/external/slangpy docs/external/stdlib-reference
           echo "Updated other submodules (slangpy, stdlib-reference)"
 
-      - name: Check if submodules changed
+      - name: Check for changes
         id: check_changes
         run: |
+          git add -A
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected."
           else
             echo "changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected."
           fi
 
       - name: Commit and push changes to stable branch
         if: steps.check_changes.outputs.changes == 'true'
         run: |
+          git add -A
           git commit -m "Sync stable: Update submodules (slang@${{ steps.slang_latest_tag.outputs.tag }})"
-          # Force push the current HEAD (main + submodule updates) to stable
           git push origin HEAD:stable --force
+          echo "Committed and force-pushed updates to stable branch."
 
       - name: Trigger Read the Docs Build on stable branch update
         if: steps.check_changes.outputs.changes == 'true'
@@ -73,4 +77,5 @@ jobs:
         run: |
           curl -X POST \
                -H "Authorization: token $RTD_WEBHOOK_SECRET" \
-               https://readthedocs.org/api/v2/webhook/shader-slanggithubio-aidanfnv-wip/295699/
+               https://readthedocs.org/api/v2/webhook/slang-documentation/296117/
+          echo "Triggered Read the Docs build."

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.PAT }}
           # Fetch all history for all branches and tags
           fetch-depth: 0
           # Get submodules

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@github.com'
+          git config --global user.name 'Read the Docs Bot'
+          git config --global user.email 'rtd-bot@shader-slang.com'
 
       - name: Get default branch
         id: default_branch

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.PAT }}
           # Fetch all history for all branches and tags
           fetch-depth: 0
           # Get submodules
@@ -54,4 +53,13 @@ jobs:
         run: |
           git add -A
           git commit -m "Auto-update submodules"
-          git push origin ${{ steps.default_branch.outputs.name }} 
+          git push origin ${{ steps.default_branch.outputs.name }}
+
+      - name: Trigger Read the Docs Build
+        if: steps.check_changes.outputs.changes == 'true'
+        env:
+          RTD_WEBHOOK_SECRET: ${{ secrets.RTD_WEBHOOK_SECRET }}
+        run: |
+          curl -X POST \
+               -H "Authorization: token $RTD_WEBHOOK_SECRET" \
+               https://readthedocs.org/api/v2/webhook/shader-slanggithubio-aidanfnv-wip/295699/ 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -44,14 +44,17 @@ jobs:
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected."
           else
             echo "changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected."
           fi
 
       - name: Commit and push changes
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          git add -A
+          # Explicitly stage the updated submodule references
+          git add docs/external/slang docs/external/slangpy docs/external/stdlib-reference
           git commit -m "Auto-update submodules"
           git push origin ${{ steps.default_branch.outputs.name }}
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -42,18 +42,23 @@ jobs:
       - name: Check if submodules changed
         id: check_changes
         run: |
-          if [[ -n "$(git diff --submodule=diff HEAD)" ]]; then
+          git add -A
+          
+          # Check if the index differs from HEAD
+          # git diff --cached --quiet exits 0 if no diff, 1 if diff
+          if ! git diff --cached --quiet; then
+            echo "Changes detected in submodule references."
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected."
           else
+            echo "No changes detected in submodule references."
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected."
+            # If no changes, reset the index in case unrelated changes were staged
+            git reset HEAD --quiet
           fi
 
       - name: Commit and push changes
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          git add -A
           git commit -m "Auto-update submodules"
           git push origin ${{ steps.default_branch.outputs.name }}
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -62,4 +62,4 @@ jobs:
         run: |
           curl -X POST \
                -H "Authorization: token $RTD_WEBHOOK_SECRET" \
-               https://readthedocs.org/api/v2/webhook/shader-slanggithubio-aidanfnv-wip/295699/ 
+               https://readthedocs.org/api/v2/webhook/slang-documentation/296117/

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check if submodules changed
         id: check_changes
         run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
+          if [[ -n "$(git diff --submodule=diff HEAD)" ]]; then
             echo "changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected."
           else
@@ -53,8 +53,7 @@ jobs:
       - name: Commit and push changes
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          # Explicitly stage the updated submodule references
-          git add docs/external/slang docs/external/slangpy docs/external/stdlib-reference
+          git add -A
           git commit -m "Auto-update submodules"
           git push origin ${{ steps.default_branch.outputs.name }}
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@github.com'
 
       - name: Get default branch
         id: default_branch


### PR DESCRIPTION
Fixes #74 

This change adds a periodic GitHub Action that pulls the main branch, checks out the latest release of Slang for the slang submodule (instead of using the master branch), and then force pushes the updated main branch and release submodule to the branch "stable", which will be used for the stable branch of the readthedocs site.

readthedocs does not recognize pushes from GitHub Actions bots, so the final step is to post a token to the site's webhook to directly trigger a new build. This change also adds that step to the submodule sync action.