### PR TITLE
Update readthedocs webhook syntax and branches

### DIFF
--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -78,6 +78,6 @@ jobs:
           RTD_WEBHOOK_SECRET: ${{ secrets.RTD_WEBHOOK_SECRET }}
         run: |
           curl -X POST \
-               -H "Authorization: token $RTD_WEBHOOK_SECRET" \
+               -d "branches=stable" -d "token=$RTD_WEBHOOK_SECRET" \
                https://readthedocs.org/api/v2/webhook/slang-documentation/296117/
-          echo "Triggered Read the Docs build."
+          echo "Triggered Read the Docs build for stable branch."

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -68,5 +68,6 @@ jobs:
           RTD_WEBHOOK_SECRET: ${{ secrets.RTD_WEBHOOK_SECRET }}
         run: |
           curl -X POST \
-               -H "Authorization: token $RTD_WEBHOOK_SECRET" \
+               -d "branches=${{ steps.default_branch.outputs.name }}" -d "token=$RTD_WEBHOOK_SECRET" \
                https://readthedocs.org/api/v2/webhook/slang-documentation/296117/
+          echo "Triggered Read the Docs build for ${{ steps.default_branch.outputs.name }} branch."


### PR DESCRIPTION
Fixes #74 

The existing readthedocs webhooks do not properly rebuild the stable branch of the docs, because if the branch is not specified, RTD instead rebuilds the "latest" branch of the docs, which is tied to branch main in this repo.

This change adds the branch name to the webhook curl. If main is pushed, latest RTD will build, and if stable is pushed, stable RTD will build. If any other branch is pushed, RTD will not do anything.