### PR TITLE
Rename stdlib reference URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "docs/external/slangpy"]
 	path = docs/external/slangpy
 	url = https://github.com/shader-slang/slangpy.git
-[submodule "docs/external/stdlib-reference"]
-	path = docs/external/stdlib-reference
+[submodule "docs/external/core-module-reference"]
+	path = docs/external/core-module-reference
 	url = https://github.com/shader-slang/stdlib-reference.git

--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -5,7 +5,7 @@ overview:
     link_label: "User Guide"
   - title: "Standard Modules Reference"
     description: "The reference of the standard modules that comes with the Slang compiler."
-    link_url: "https://docs.shader-slang.org/en/latest/external/stdlib-reference/"
+    link_url: "https://docs.shader-slang.org/en/latest/external/core-module-reference/"
     link_label: "Modules Reference"
   - title: "Language Specification"
     description: "The formal specification of the Slang programming language. Work in progress.."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,11 +69,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'index.md',
 ]
 include_patterns = ['index.rst', '*.md',
                     "external/slang/docs/user-guide/*.md",
-                    "external/stdlib-reference/index.md",
-                    "external/stdlib-reference/attributes/**",
-                    "external/stdlib-reference/global-decls/**",
-                    "external/stdlib-reference/interfaces/**",
-                    "external/stdlib-reference/types/**",
+                    "external/core-module-reference/index.md",
+                    "external/core-module-reference/attributes/**",
+                    "external/core-module-reference/global-decls/**",
+                    "external/core-module-reference/interfaces/**",
+                    "external/core-module-reference/types/**",
                     "external/slangpy/docs/**",
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Slang Documentation
    :titlesonly:
 
    User Guide <external/slang/docs/user-guide/index>
-   Standard Modules Reference <external/stdlib-reference/index>
+   Standard Modules Reference <external/core-module-reference/index>
    Language Spec <https://github.com/shader-slang/spec>
    SlangPy User Guide <external/slangpy/docs/index.rst>
    Feature Matureness <feature_matureness>

--- a/docs/understanding-generics.md
+++ b/docs/understanding-generics.md
@@ -334,9 +334,9 @@ float addValue<T>(T v0, T v1) where T : IArithmetic { return v0 + v1; }
 
 It is still possible to write functions which can generically operate over
 scalars and vectors, for example using the
-[`IArithmetic`](https://shader-slang.com/stdlib-reference/interfaces/iarithmetic-01/index.html)
+[`IArithmetic`](https://docs.shader-slang.org/en/latest/external/core-module-reference/interfaces/iarithmetic-01/index.html)
 or
-[`IFloat`](https://shader-slang.com/stdlib-reference/interfaces/ifloat-01/index.html)
+[`IFloat`](https://docs.shader-slang.org/en/latest/external/core-module-reference/interfaces/ifloat-01/index.html)
 interfaces.
 
 ### Advanced Generic Features


### PR DESCRIPTION
Related to https://github.com/shader-slang/slang/issues/6770

Since the Standard Module Reference repo is going to be renamed eventually, this change renames the submodule in this repo to core-module-reference, changing the readthedocs URLs accordingly, while these docs are still relatively new rather than change the URLs later on or have URLs with the old repo name.