### PR TITLE
Port semantic and section highlighting from stdlib-reference to ReadTheDocs

### DIFF
--- a/docs/_static/section_highlight.js
+++ b/docs/_static/section_highlight.js
@@ -1,0 +1,26 @@
+// Add highlight to the target section
+const hash = window.location.hash.substring(1);
+
+// Highlight the currently visiting section.
+function highlightHashSection(hashName) {
+    const elements = document.querySelectorAll('[id="' + hashName + '"]');
+    elements.forEach(anchor => {
+        anchor.classList.add('goto_highlight');
+        setTimeout(() => {
+            anchor.classList.add('goto_highlight_fade_out');
+            setTimeout(() => {
+                anchor.classList.remove('goto_highlight');
+                anchor.classList.remove('goto_highlight_fade_out');
+            }, 2000);
+        }, 5000);
+    });
+}
+
+// Initial highlight on page load
+highlightHashSection(hash);
+
+// Highlight on hash change
+window.onhashchange = function() {
+    const newHash = window.location.hash.substring(1);
+    highlightHashSection(newHash);
+}; 

--- a/docs/_static/section_highlight.js
+++ b/docs/_static/section_highlight.js
@@ -1,26 +1,75 @@
 // Add highlight to the target section
 const hash = window.location.hash.substring(1);
 
-// Highlight the currently visiting section.
 function highlightHashSection(hashName) {
+    if (!hashName) return;
     const elements = document.querySelectorAll('[id="' + hashName + '"]');
     elements.forEach(anchor => {
-        anchor.classList.add('goto_highlight');
-        setTimeout(() => {
-            anchor.classList.add('goto_highlight_fade_out');
+        let target = null;
+        // If the anchor is inside a heading, highlight the heading
+        if (anchor.parentElement && /^H[1-6]$/.test(anchor.parentElement.tagName)) {
+            target = anchor.parentElement;
+        }
+        // If the anchor is an empty <a> or <span>, try to find the next visible heading/field sibling
+        if (!target && (anchor.tagName === 'A' || anchor.tagName === 'SPAN') && (!anchor.textContent.trim() || anchor.offsetHeight === 0)) {
+            let sibling = anchor.nextSibling;
+            while (sibling) {
+                if (sibling.nodeType === 1 && // ELEMENT_NODE
+                    (
+                        ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'DT', 'DD', 'LI', 'PRE', 'TR'].includes(sibling.tagName) ||
+                        sibling.classList.contains('field') ||
+                        sibling.classList.contains('field-item') ||
+                        sibling.classList.contains('highlight') ||
+                        sibling.classList.contains('code')
+                    )
+                ) {
+                    target = sibling;
+                    break;
+                }
+                sibling = sibling.nextSibling;
+            }
+        }
+        // Fallback: traverse up to find a field/code/line container, but not a generic div or section
+        if (!target) {
+            let up = anchor;
+            while (up && up.parentElement) {
+                if (
+                    ['LI', 'DT', 'DD', 'TR', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(up.tagName) ||
+                    up.classList.contains('field') ||
+                    up.classList.contains('field-item') ||
+                    up.classList.contains('highlight') ||
+                    up.classList.contains('code')
+                ) {
+                    target = up;
+                    break;
+                }
+                up = up.parentElement;
+            }
+        }
+        // Only highlight if the target is visible, not whitespace, and not a section/article/div
+        if (
+            target &&
+            target.offsetHeight > 0 &&
+            target.textContent.trim() &&
+            !['SECTION', 'ARTICLE', 'DIV', 'BODY', 'HTML'].includes(target.tagName)
+        ) {
+            target.classList.add('goto_highlight');
             setTimeout(() => {
-                anchor.classList.remove('goto_highlight');
-                anchor.classList.remove('goto_highlight_fade_out');
-            }, 2000);
-        }, 5000);
+                target.classList.add('goto_highlight_fade_out');
+                setTimeout(() => {
+                    target.classList.remove('goto_highlight');
+                    target.classList.remove('goto_highlight_fade_out');
+                }, 2000);
+            }, 5000);
+        }
     });
 }
 
-// Initial highlight on page load
-highlightHashSection(hash);
-
-// Highlight on hash change
-window.onhashchange = function() {
-    const newHash = window.location.hash.substring(1);
-    highlightHashSection(newHash);
-}; 
+document.addEventListener('DOMContentLoaded', function() {
+    const hash = window.location.hash.substring(1);
+    highlightHashSection(hash);
+    window.onhashchange = function() {
+        const newHash = window.location.hash.substring(1);
+        highlightHashSection(newHash);
+    };
+}); 

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -108,9 +108,7 @@ https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
 /* Section highlighting styles */
 .goto_highlight {
   animation: highlight-fade-in 0.5s ease-in;
-  background-color: rgba(255, 255, 0, 0.2);
-  border-radius: 4px;
-  padding: 2px 4px;
+  background-color: rgba(255, 255, 128, 0.5);
 }
 
 .goto_highlight_fade_out {

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -28,83 +28,6 @@ https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
     display: block !important;
 }
 
-/* Semantic highlighting styles */
-.highlight .cm, .highlight .cp, .highlight .c1, .highlight .cs,
-.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
-  color: #148b04;
-}
-.highlight .err {
-  color: #a61717;
-  background-color: #e3d2d2;
-}
-.highlight .gd {
-  color: #000000;
-  background-color: #ffdddd;
-}
-.highlight .ge {
-  color: #000000;
-  font-style: italic;
-}
-.highlight .gr {
-  color: #aa0000;
-}
-.highlight .gh {
-  color: #999999;
-}
-.highlight .gi {
-  color: #000000;
-  background-color: #ddffdd;
-}
-.highlight .go {
-  color: #888888;
-}
-.highlight .gp {
-  color: #555555;
-}
-.highlight .gu {
-  color: #aaaaaa;
-}
-.highlight .gt {
-  color: #aa0000;
-}
-.highlight .kc, .highlight .kd, .highlight .kn, .highlight .kp,
-.highlight .kr, .highlight .kt, .highlight .k, .highlight .kv {
-  color: #1243d4;
-}
-.highlight .m, .highlight .mb, .highlight .mx, .highlight .mi, .highlight .mf {
-  color: #7211c2;
-}
-.highlight .sa {
-  color: #000000;
-}
-.highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2,
-.highlight .se, .highlight .sh, .highlight .si, .highlight .sx,
-.highlight .s1, .highlight .s, .highlight .dl {
-  color: #d14;
-}
-.highlight .sr {
-  color: #009926;
-}
-.highlight .ss {
-  color: #990073;
-}
-.highlight .na, .highlight .vc, .highlight .vg, .highlight .vi,
-.highlight .nv, .highlight .vm {
-  color: #008080;
-}
-.highlight .bp {
-  color: #999999;
-}
-.highlight .n {
-  color: black;
-}
-.highlight .nc, .highlight .nt {
-  color: #11abb9;
-}
-.highlight .ow, .highlight .o, .highlight .w, .highlight .p {
-  color: #000000;
-}
-
 /* Section highlighting styles */
 .goto_highlight {
   animation: highlight-fade-in 0.5s ease-in;
@@ -146,4 +69,38 @@ pre code {
 
 .highlight {
   background: #F8F8F8;
+}
+
+/* Custom syntax highlighting for Slang-specific classes */
+pre .code_keyword {
+  color: #1243d4 !important; /* Blue - for keywords like 'int' */
+}
+
+pre .code_type {
+  color: #11abb9 !important; /* Teal/Cyan - for types like 'Array' */
+}
+
+pre .code_var {
+  color: #0a1985 !important; /* Color for variables like 'N' */
+}
+
+/* Target 'a' tags directly within 'pre' blocks for method names */
+pre a, pre a:visited { /* Added :visited for consistency */
+  color: #d14 !important;   /* Dark Pink/Red - for method names like 'getCount' */
+  text-decoration: none !important; 
+}
+
+pre a:hover {
+  text-decoration: underline !important;
+}
+
+pre a.code_param {
+  color: #808080 !important; /* Gray for parameters */
+}
+
+/* General text in pre blocks, if not caught by other rules, should be black. */
+/* This might be slightly redundant given existing rules, but ensures our intent. */
+pre, pre code {
+    color: black !important; /* Default code text color */
+    /* background-color: #F8F8F8; /* Already set by existing rules */
 }

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -96,22 +96,48 @@ pre .code_type {
   color: #11abb9 !important; /* Teal/Cyan - for types like 'Array' */
 }
 
+pre .code_param {
+  color: #808080 !important; /* Gray */
+}
+
 pre .code_var {
   color: #0a1985 !important; /* Color for variables like 'N' */
 }
 
-/* Target 'a' tags directly within 'pre' blocks for method names */
-pre a, pre a:visited { /* Added :visited for consistency */
-  color: #d14 !important;   /* Dark Pink/Red - for method names like 'getCount' */
+/* Link styling within <pre> blocks */
+
+/* Default/Method links (e.g., getCount) */
+pre a,
+pre a:link, /* Explicitly for unvisited */
+pre a:visited {
+  color: #d14 !important;   /* Dark Pink/Red - for method names */
   text-decoration: none !important; 
 }
 
-pre a:hover {
-  text-decoration: underline !important;
+/* Type links (e.g., Array) */
+pre a.code_type,
+pre a.code_type:link,
+pre a.code_type:visited { 
+  color: #11abb9 !important; /* Teal/Cyan */
 }
 
-pre a.code_param {
-  color: #808080 !important; /* Gray for parameters */
+/* Parameter links (e.g., a, b in dadd.md) */
+pre a.code_param,
+pre a.code_param:link,
+pre a.code_param:visited {
+  color: #808080 !important; /* Gray */
+}
+
+/* Variable links */
+pre a.code_var,
+pre a.code_var:link,
+pre a.code_var:visited {
+  color: #0a1985 !important; /* Color for variable links */
+}
+
+/* Common hover effect for all these links */
+pre a:hover {
+  text-decoration: underline !important;
 }
 
 /* General text in pre blocks, if not caught by other rules, should be black. */

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -28,6 +28,22 @@ https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
     display: block !important;
 }
 
+/* Pygments Sytnax Highlighting for Furo Theme Override */
+.highlight .k, .highlight .kc, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr { color: #1243d4 !important; } /* Keywords */
+.highlight .kt, .highlight .nc { color: #11abb9 !important; } /* Types, Class names */
+.highlight .nv { color: #0a1985 !important; } /* Variables, e.g. instance variables */
+.highlight .nb { color: #0a1985 !important; } /* Built-in names, can also be variable-like */
+.highlight .n, .highlight .nn { color: #000000 !important; } /* General names, namespace names - default to black */
+
+.highlight .nf { color: #d14 !important; } /* Function names */
+.highlight .c, .highlight .c1, .highlight .cs, .highlight .cm { color: #149104 !important; } /* Comments - green */
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .sd, .highlight .se, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr { color: #d14 !important; } /* Strings, Regex - using the red/pink */
+.highlight .m, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo { color: #7211c2 !important; } /* Numbers - purple */
+
+/* Ensure other elements like operators are sensible */
+.highlight .o, .highlight .ow { color: #000000 !important; } /* Operators - black */
+.highlight .p { color: #000000 !important; } /* Punctuation - black */
+
 /* Section highlighting styles */
 .goto_highlight {
   animation: highlight-fade-in 0.5s ease-in;

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -120,3 +120,56 @@ pre, pre code {
     color: black !important; /* Default code text color */
     /* background-color: #F8F8F8; /* Already set by existing rules */
 }
+
+/* Custom Heading Sizes and Spacing */
+h1 {
+    font-size: 2.0em !important;
+    /* Furo specific line-height might need adjustment if text looks cramped */
+}
+
+h2 {
+    font-size: 1.75em !important;
+}
+
+h3 {
+    font-size: 1.5em !important;
+}
+
+h4 {
+    font-size: 1.25em !important;
+    /* font-weight: bold !important; */
+}
+
+h5 {
+    font-size: 1.0em !important;
+    /* font-weight: bold !important; */
+}
+
+h6 {
+    font-size: 0.75em !important;
+    font-weight: bold !important;
+    color: #555 !important; /* Often H6 is a bit de-emphasized */
+}
+
+/* Heading styles for core-module-reference (Tactile-like) */
+/* Applied using the data-furo-page attribute */
+
+body.core-module-reference-page h1 {
+    font-size: 2.25em !important;
+    font-weight: 700 !important;
+}
+
+body.core-module-reference-page h2 {
+    font-size: 1.5em !important;
+    font-weight: 700 !important;
+}
+
+body.core-module-reference-page h3 {
+    font-size: 1.0em !important; /* Matches Tactile theme */
+    font-weight: 700 !important;
+}
+
+body.core-module-reference-page h4 {
+    font-size: 1.2em !important; /* Matches Tactile theme */
+    font-weight: 700 !important;
+}

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -27,3 +27,125 @@ https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
 .py.property {
     display: block !important;
 }
+
+/* Semantic highlighting styles */
+.highlight .cm, .highlight .cp, .highlight .c1, .highlight .cs,
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+  color: #148b04;
+}
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #aa0000;
+}
+.highlight .gh {
+  color: #999999;
+}
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .gt {
+  color: #aa0000;
+}
+.highlight .kc, .highlight .kd, .highlight .kn, .highlight .kp,
+.highlight .kr, .highlight .kt, .highlight .k, .highlight .kv {
+  color: #1243d4;
+}
+.highlight .m, .highlight .mb, .highlight .mx, .highlight .mi, .highlight .mf {
+  color: #7211c2;
+}
+.highlight .sa {
+  color: #000000;
+}
+.highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2,
+.highlight .se, .highlight .sh, .highlight .si, .highlight .sx,
+.highlight .s1, .highlight .s, .highlight .dl {
+  color: #d14;
+}
+.highlight .sr {
+  color: #009926;
+}
+.highlight .ss {
+  color: #990073;
+}
+.highlight .na, .highlight .vc, .highlight .vg, .highlight .vi,
+.highlight .nv, .highlight .vm {
+  color: #008080;
+}
+.highlight .bp {
+  color: #999999;
+}
+.highlight .n {
+  color: black;
+}
+.highlight .nc, .highlight .nt {
+  color: #11abb9;
+}
+.highlight .ow, .highlight .o, .highlight .w, .highlight .p {
+  color: #000000;
+}
+
+/* Section highlighting styles */
+.goto_highlight {
+  animation: highlight-fade-in 0.5s ease-in;
+  background-color: rgba(255, 255, 0, 0.2);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+.goto_highlight_fade_out {
+  animation: highlight-fade-out 2s ease-out;
+}
+
+@keyframes highlight-fade-in {
+  from {
+    background-color: rgba(255, 255, 0, 0);
+  }
+  to {
+    background-color: rgba(255, 255, 0, 0.2);
+  }
+}
+
+@keyframes highlight-fade-out {
+  from {
+    background-color: rgba(255, 255, 0, 0.2);
+  }
+  to {
+    background-color: rgba(255, 255, 0, 0);
+  }
+}
+
+/* Code block styles */
+pre {
+  color: #000000;
+  background: #F8F8F8;
+}
+
+pre code {
+  color: #000000;
+  background-color: #F8F8F8;
+}
+
+.highlight {
+  background: #F8F8F8;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,10 @@ html_theme = "furo"
 html_title = "Slang Documentation"
 html_static_path = ['_static']
 html_css_files = ["theme_overrides.css"]
-html_js_files = ["section_highlight.js"]
+html_js_files = [
+    "section_highlight.js",
+    "custom_body_classes.js",
+]
 html_theme_options = {
     "light_css_variables": {
         "color-api-background": "#f7f7f7",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ html_theme = "furo"
 html_title = "Slang Documentation"
 html_static_path = ['_static']
 html_css_files = ["theme_overrides.css"]
+html_js_files = ["section_highlight.js"]
 html_theme_options = {
     "light_css_variables": {
         "color-api-background": "#f7f7f7",


### PR DESCRIPTION
Fixes #79 

This change ports over the section highlighting from https://shader-slang.org/stdlib-reference/global-decls/ to the readthedocs site, as well as the semantic highlighting and styles as well. It also adjusts the relative sizing of the headings to more closely resemble that site as well. RTD does have section highlighting built-in, but not when clicking on links, only when clicking on the section's pilcrow (¶).

A preview of the changes to the docs can be seen here: https://shader-slanggithubio-aidanfnv-wip.readthedocs.io/en/fix-readthedocs-highlighting/