### PR TITLE
Exclude SlangPy docs from ReadTheDocs site build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ include_patterns = ['index.rst', '*.md',
                     "external/core-module-reference/global-decls/**",
                     "external/core-module-reference/interfaces/**",
                     "external/core-module-reference/types/**",
-                    "external/slangpy/docs/**",
+                    "external/slangpy/docs/index.rst",
 ]
 
 # Configure myst-parser for markdown files


### PR DESCRIPTION
To help with #96 

This change excludes all of the slangpy docs from the RTD build, except for the index.rst, since we are currently using a redirect to point away from there towards the dedicated SlangPy RTD site for now. Excluding these docs will provide a reduction to the site's build times while a longer-term solution (as laid out in #96) is implemented.