### PR TITLE
Use dollarmath for rendering LaTeX on ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,8 +41,33 @@ def handle_utf16le_files(app, docname, source):
             # Set the source content
             source[0] = content
 
+def latex_block_to_inline(app, docname, source):
+    content = source[0]
+    # Replace $$ with $ for inline math, but only when not part of a block
+    # First find all block math ($$...$$) on their own lines
+    block_matches = re.finditer(r'^\s*\$\$(.*?)\$\$\s*$', content, re.MULTILINE | re.DOTALL)
+    block_positions = [(m.start(), m.end()) for m in block_matches]
+    
+    # Now find all $$ pairs
+    all_matches = list(re.finditer(r'\$\$(.*?)\$\$', content, re.DOTALL))
+    
+    # Filter to only inline matches by checking if they overlap with any block matches
+    def is_inline(match):
+        pos = match.span()
+        return not any(block_start <= pos[0] <= block_end for block_start, block_end in block_positions)
+    
+    inline_matches = [m for m in all_matches if is_inline(m)]
+    
+    # Replace inline $$ with $ working backwards to preserve positions
+    for match in reversed(inline_matches):
+        start, end = match.span()
+        inner = match.group(1)
+        content = content[:start] + '$' + inner + '$' + content[end:]
+    source[0] = content
+
 def setup(app):
     app.connect('source-read', source_read_handler)
+    app.connect('source-read', latex_block_to_inline)
     app.connect('source-read', handle_utf16le_files)
 
 project = 'Slang Documentation'
@@ -86,11 +111,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'index.md',
 include_patterns = ['index.rst', '*.md',
                     "external/slang/docs/user-guide/*.md",
                     "external/slang/docs/command-line-slangc-reference.md",
-                    "external/core-module-reference/index.md",
-                    "external/core-module-reference/attributes/**",
-                    "external/core-module-reference/global-decls/**",
-                    "external/core-module-reference/interfaces/**",
-                    "external/core-module-reference/types/**",
                     "external/slangpy/docs/index.rst",
 ]
 


### PR DESCRIPTION
Fixes #107

This change adds the "dollarmath" MyST extension to the Sphinx config used by the ReadTheDocs site, so that markdown enclosed in dollar signs, e.g.
![image](https://github.com/user-attachments/assets/c72ec9a2-42f2-425f-bdcf-31f8e67418d3)
gets properly rendered as LaTeX expressions:
![image](https://github.com/user-attachments/assets/8f3a6953-dc66-4c40-b725-dd64c7bb7a52)

It also adds a preprocessing step that replaces all of the $$ delimiters around inline expressions with $, to make them compatible with dollarmath without breaking existing compatibility with Jekyll/MathJax (see https://github.com/shader-slang/slang/pull/6294).
With $$ around inline expressions:
![image](https://github.com/user-attachments/assets/77f0370d-e622-46fe-8ad2-165bd1fe7000)
With those $$ replaced with $:
![image](https://github.com/user-attachments/assets/13af248f-9d4d-4319-9486-c282cad4098f)



