### PR TITLE
Add slang release branch change to stable commit

### DIFF
--- a/.github/workflows/sync-stable-branch.yml
+++ b/.github/workflows/sync-stable-branch.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Commit and push changes to stable branch
         run: |
+          git add docs/external/slang
           git commit -m "Sync stable to release (slang@${{ steps.slang_latest_tag.outputs.tag }})"
           git push origin HEAD:stable --force
           echo "Committed and force-pushed updates to stable branch."


### PR DESCRIPTION
This change fixes an issue with the ReadTheDocs "stable" branch syncing where the switch to the release tag is not added to the commit that gets force pushed, resulting in the "latest" docs being used for "stable".