### PR TITLE
Restore core module reference to RTD include list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'index.md',
 include_patterns = ['index.rst', '*.md',
                     "external/slang/docs/user-guide/*.md",
                     "external/slang/docs/command-line-slangc-reference.md",
+                    "external/core-module-reference/index.md",
+                    "external/core-module-reference/attributes/**",
+                    "external/core-module-reference/global-decls/**",
+                    "external/core-module-reference/interfaces/**",
+                    "external/core-module-reference/types/**",
                     "external/slangpy/docs/index.rst",
 ]
 


### PR DESCRIPTION
https://github.com/shader-slang/shader-slang.github.io/pull/111 erroneously removed the core module reference from the RTD build's include list, causing the pages to disappear from the docs site.
That removal was intended only for local testing purposes.

This change undoes that removal, restoring the pages.