### PR TITLE
Get location of search.html and link to it properly in RTD search

### DIFF
--- a/docs/_static/search.js
+++ b/docs/_static/search.js
@@ -290,7 +290,31 @@ function txtSearchChange(event) {
     matchedResults.sort((a, b) => b.score - a.score);
 
     // Add the "Search for..." item at the top
-    resultPanel.innerHTML = `<div class='search_result_item' data-type='search'><a href="search.html?q=${encodeURIComponent(searchText)}"><span>Search Documentation for "${escapeHTML(searchText)}"</span></a></div>`;
+
+    // Get the URL root from the RTD documentation options
+    let urlRoot = DOCUMENTATION_OPTIONS.URL_ROOT;
+
+    // If the URL root is not set (e.g. for local development), get the script path and go up one directory
+    if (!urlRoot) {
+        try {
+            const scriptSrc = document.currentScript ? document.currentScript.src : 
+                              (document.scripts[document.scripts.length - 1] ? document.scripts[document.scripts.length - 1].src : '');
+            if (scriptSrc) {
+                const url = new URL(scriptSrc);
+                const pathParts = url.pathname.split('/');
+                pathParts.pop(); // Remove the script filename
+                pathParts.pop(); // Go up one directory from _static
+                urlRoot = url.origin + pathParts.join('/');
+            } else {
+                urlRoot = '';
+            }
+        } catch (e) {
+            urlRoot = '';
+        }
+    }
+    
+    searchUrl = urlRoot + '/search.html';
+    resultPanel.innerHTML = `<div class='search_result_item' data-type='search'><a href="${searchUrl}?q=${encodeURIComponent(searchText)}"><span>Search Documentation for "${escapeHTML(searchText)}"</span></a></div>`;
     
     // Add the rest of the results
     resultPanel.innerHTML += matchedResults.map(r => 

--- a/docs/_static/search.js
+++ b/docs/_static/search.js
@@ -290,12 +290,13 @@ function txtSearchChange(event) {
     matchedResults.sort((a, b) => b.score - a.score);
 
     // Add the "Search for..." item at the top
-
     // Get the URL root from the RTD documentation options
     let urlRoot = DOCUMENTATION_OPTIONS.URL_ROOT;
 
     // If the URL root is not set (e.g. for local development), get the script path and go up one directory
-    if (!urlRoot) {
+    if (urlRoot) {
+        urlRoot = urlRoot + '/';
+    } else {
         // If we're already on the search page, use relative path
         if (window.location.pathname.endsWith('/search.html')) {
             urlRoot = '';

--- a/docs/_static/search.js
+++ b/docs/_static/search.js
@@ -296,24 +296,29 @@ function txtSearchChange(event) {
 
     // If the URL root is not set (e.g. for local development), get the script path and go up one directory
     if (!urlRoot) {
-        try {
-            const scriptSrc = document.currentScript ? document.currentScript.src : 
-                              (document.scripts[document.scripts.length - 1] ? document.scripts[document.scripts.length - 1].src : '');
-            if (scriptSrc) {
-                const url = new URL(scriptSrc);
-                const pathParts = url.pathname.split('/');
-                pathParts.pop(); // Remove the script filename
-                pathParts.pop(); // Go up one directory from _static
-                urlRoot = url.origin + pathParts.join('/');
-            } else {
+        // If we're already on the search page, use relative path
+        if (window.location.pathname.endsWith('/search.html')) {
+            urlRoot = '';
+        } else {
+            try {
+                const scriptSrc = document.currentScript ? document.currentScript.src : 
+                                (document.scripts[document.scripts.length - 1] ? document.scripts[document.scripts.length - 1].src : '');
+                if (scriptSrc) {
+                    const url = new URL(scriptSrc);
+                    const pathParts = url.pathname.split('/');
+                    pathParts.pop(); // Remove the script filename
+                    pathParts.pop(); // Go up one directory from _static
+                    urlRoot = url.origin + pathParts.join('/') + '/';
+                } else {
+                    urlRoot = '';
+                }
+            } catch (e) {
                 urlRoot = '';
             }
-        } catch (e) {
-            urlRoot = '';
         }
     }
     
-    searchUrl = urlRoot + '/search.html';
+    searchUrl = urlRoot + 'search.html';
     resultPanel.innerHTML = `<div class='search_result_item' data-type='search'><a href="${searchUrl}?q=${encodeURIComponent(searchText)}"><span>Search Documentation for "${escapeHTML(searchText)}"</span></a></div>`;
     
     // Add the rest of the results

--- a/docs/_templates/sidebar/search.html
+++ b/docs/_templates/sidebar/search.html
@@ -1,7 +1,6 @@
-<div id="searchKeybindHint" style="visibility: hidden; text-align: center; font-size: 0.75em; margin-bottom: 4px; color: var(--color-foreground-muted);">Press Ctrl+Enter to search page contents</div>
 <div id="tocSearchPanel">
     <div id="tocSearchPanelInner">
         <input type="text" id="txtSearch" placeholder="Search..." autocomplete="off" />
     </div>
     <div id="tocSearchResult" style="display: none;"></div>
-</div> 
+</div>


### PR DESCRIPTION
Follow up to #80 

The `Search documentation for ...` option leads to a 404 error when selected on any page that is not at the root of the docs, as the path used in the search script is relative to the current page, not the script.

This change prepends the root of the docs to the URL for that search result, using the root URL specified in the RTD site config, so that the search result will be an absolute URL and work from any page.

If that setting does not exist (i.e. if you are building the HTML pages locally), the script falls back to using its directory parent's URL, which is currently root.