### PR TITLE
Fix RTD code block and sidebar colors in dark mode

### DIFF
--- a/docs/_ext/generate_toc_html.py
+++ b/docs/_ext/generate_toc_html.py
@@ -325,7 +325,7 @@ def generate_toc_html(app, exception):
       </symbol>
     </svg>
 </head>
-<body>
+<body data-theme="auto">
 <div class="content-container">
     <div id="tocSearchPanel">
         <div id="tocSearchPanelInner">
@@ -337,6 +337,7 @@ def generate_toc_html(app, exception):
 {html}
     </div>
 </div>
+<script src="iframe_theme_receiver.js"></script>
 <script src="toc-highlight.js"></script>
 <script src="search.js"></script>
 </body>

--- a/docs/_ext/generate_toc_html.py
+++ b/docs/_ext/generate_toc_html.py
@@ -324,6 +324,7 @@ def generate_toc_html(app, exception):
         </svg>
       </symbol>
     </svg>
+    <script src="iframe_theme_receiver.js"></script>
 </head>
 <body data-theme="auto">
 <div class="content-container">
@@ -337,7 +338,6 @@ def generate_toc_html(app, exception):
 {html}
     </div>
 </div>
-<script src="iframe_theme_receiver.js"></script>
 <script src="toc-highlight.js"></script>
 <script src="search.js"></script>
 </body>

--- a/docs/_static/iframe_theme_receiver.js
+++ b/docs/_static/iframe_theme_receiver.js
@@ -1,0 +1,6 @@
+// Listen for theme changes from parent window
+window.addEventListener('message', function(event) {{
+    if (event.data && event.data.type === 'theme-change') {{
+        document.body.setAttribute('data-theme', event.data.theme);
+    }}
+}});

--- a/docs/_static/iframe_theme_sync.js
+++ b/docs/_static/iframe_theme_sync.js
@@ -1,0 +1,55 @@
+// Theme synchronization for iframe
+(function() {
+    'use strict';
+    
+    // Function to notify iframe about theme changes
+    function notifyIframeOfThemeChange(theme) {
+        const iframe = document.querySelector('.custom-nav iframe');
+        if (iframe && iframe.contentWindow) {
+            try {
+                iframe.contentWindow.postMessage({
+                    type: 'theme-change',
+                    theme: theme
+                }, '*');
+            } catch (e) {
+                console.warn('Could not send theme change message to iframe:', e);
+            }
+        }
+    }
+    
+    // Function to get current theme
+    function getCurrentTheme() {
+        return document.body.getAttribute('data-theme') || 'auto';
+    }
+    
+    // Monitor theme changes using MutationObserver
+    function observeThemeChanges() {
+        const observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+                    const newTheme = getCurrentTheme();
+                    notifyIframeOfThemeChange(newTheme);
+                }
+            });
+        });
+        
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['data-theme']
+        });
+    }
+    
+    // Initialize when DOM is ready
+    document.addEventListener('DOMContentLoaded', function() {
+        // Start observing theme changes
+        observeThemeChanges();
+        
+        // Send initial theme when iframe loads
+        const iframe = document.querySelector('.custom-nav iframe');
+        if (iframe) {
+            iframe.addEventListener('load', function() {
+                notifyIframeOfThemeChange(getCurrentTheme());
+            });
+        }
+    });
+})(); 

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -305,7 +305,6 @@ form.sidebar-search-container {
 /* Code block styles */
 pre, pre code {
     color: #000000 !important;
-    background: #F8F8F8 !important;
 }
 
 /* Code block styling */

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ html_js_files = [
     "search.js",
     "section_highlight.js",
     "custom_body_classes.js",
+    "iframe_theme_sync.js",
 ]
 html_theme_options = {
     "light_css_variables": {


### PR DESCRIPTION
Fixes #118 
Fixes https://github.com/shader-slang/slang/issues/7442

This change removes the white background color from code blocks, so that in dark mode they will use the default background color, allowing dark mode's light text to be visible.

A preview of what the code blocks and sidebar look like can be seen at: https://shader-slanggithubio-aidanfnv-wip.readthedocs.io/en/fix-rtd-dark-mode/external/slang/docs/user-guide/01-get-started.html
![image](https://github.com/user-attachments/assets/c6140c5d-9421-41c6-b887-c89d6192c29f)

The dark mode text colors use the defaults instead of the manually defined colors used for light mode. The colors can be changed later.
