### PR TITLE
Fix ReadTheDocs TOC scrolling to properly save scrollbar position

### DIFF
--- a/docs/_static/toc-highlight.js
+++ b/docs/_static/toc-highlight.js
@@ -19,19 +19,8 @@ document.addEventListener('DOMContentLoaded', function() {
         // If we found the current page, expand the path to it and expand its children
         if (currentPageElement) {
             expandPathToElementAndChildren(currentPageElement);
-            
-            // After expansion, restore the scroll position
             restoreScrollPosition();
-                
-            // Check if current page is still visible after restoration
-            const rect = currentPageElement.getBoundingClientRect();
-            if (rect.top < 0 || rect.top > window.innerHeight) {
-                // Current page is not visible, scroll to show it
-                currentPageElement.scrollIntoView({
-                    behavior: 'instant',
-                    block: 'nearest'
-                });
-            }
+            scrollToElementIfNotVisible(currentPageElement);
         }
         
     } catch (e) {
@@ -44,6 +33,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function expandPathToElementAndChildren(element) {
+    console.log('Expanding path to element and its children...');
     // Start from the current page's list item
     let currentLi = element.closest('li');
     if (!currentLi) return;
@@ -77,26 +67,60 @@ function expandPathToElementAndChildren(element) {
         // Move up to the next level
         currentLi = parentLi;
     }
+    console.log('Expanded path to element and its children');
 } 
 
 function saveScrollPosition() {
+    console.log('Saving scroll position...');
     try {
-        window.savedScrollPosition = window.pageYOffset || document.documentElement.scrollTop;
+        // Target the toc-content div which has the scroll attribute
+        const scrollableContainer = document.querySelector('.toc-content');
+        if (!scrollableContainer) {
+            console.log('No .toc-content element found!');
+            return;
+        }
+        // Use sessionStorage to persist the scroll position across page loads.
+        sessionStorage.setItem('sidebarScrollPosition', scrollableContainer.scrollTop);
+        console.log('Saved scroll position to', scrollableContainer.scrollTop);
     } catch (e) {
         console.log('Could not save scroll position:', e);
     }
 }
 
 function restoreScrollPosition() {
+    console.log('Restoring scroll position...');
     try {
-        if (window.savedScrollPosition === undefined) return;
+        const scrollableContainer = document.querySelector('.toc-content');
+        if (!scrollableContainer) {
+            console.log('No .toc-content element found!');
+            return;
+        }
+
+        const savedScrollPosition = sessionStorage.getItem('sidebarScrollPosition');
+        if (savedScrollPosition === null) {
+            console.log('No scroll position to restore!');
+            return;
+        };
         
-        // Restore the exact scroll position
-        window.scrollTo({
-            top: window.savedScrollPosition,
-            behavior: 'instant'
-        });
+        // Restore scroll position to the toc-content container
+        scrollableContainer.scrollTop = parseInt(savedScrollPosition, 10);
+        console.log('Restored scroll position to', parseInt(savedScrollPosition, 10));
     } catch (e) {
         console.log('Could not restore scroll position:', e);
     }
-} 
+}
+
+function scrollToElementIfNotVisible(element) {
+    console.log('Checking if current page is visible...');
+    const rect = element.getBoundingClientRect();
+    if (rect.top < 0 || rect.top > window.innerHeight) {
+        console.log('Current page is not visible, scrolling to show it...');
+        element.scrollIntoView({
+            behavior: 'instant',
+            block: 'center'
+        });
+        console.log('Scrolled current page into view');
+    } else {
+        console.log('Current page is visible');
+    }
+}

--- a/docs/_static/toc-highlight.js
+++ b/docs/_static/toc-highlight.js
@@ -4,30 +4,29 @@ document.addEventListener('DOMContentLoaded', function() {
         const parentUrl = window.parent.location.href;
         const links = document.querySelectorAll('.sidebar-tree a.reference');
         let currentPageElement = null;
-        
+
         links.forEach(function(link) {
             const linkUrl = new URL(link.href, window.location.origin);
             const parentUrlObj = new URL(parentUrl);
-            
+
             // Compare the pathname (ignoring hash and query parameters)
             if (linkUrl.pathname === parentUrlObj.pathname) {
                 link.parentElement.classList.add('current-page');
                 currentPageElement = link.parentElement;
             }
         });
-        
+
         // If we found the current page, expand the path to it and expand its children
         if (currentPageElement) {
             expandPathToElementAndChildren(currentPageElement);
             restoreScrollPosition();
             scrollToElementIfNotVisible(currentPageElement);
         }
-        
     } catch (e) {
         // Log that we can't access parent URL due to cross-origin restrictions
         console.log('Cannot access parent URL:', e);
     }
-    
+
     // Save scroll position when page unloads
     window.addEventListener('beforeunload', saveScrollPosition);
 });
@@ -37,13 +36,13 @@ function expandPathToElementAndChildren(element) {
     // Start from the current page's list item
     let currentLi = element.closest('li');
     if (!currentLi) return;
-    
+
     // First, expand the current page's own children if it has any
     const currentCheckbox = currentLi.querySelector(':scope > .toctree-checkbox');
     if (currentCheckbox) {
         currentCheckbox.checked = true;
     }
-    
+
     // Then walk up the ancestry to expand the path to this element
     while (currentLi) {
         // Find the parent ul of this li
@@ -51,24 +50,24 @@ function expandPathToElementAndChildren(element) {
         if (!parentUl || parentUl.tagName !== 'UL') {
             break;
         }
-        
+
         // Find the parent li of that ul (this is the section that contains our current path)
         const parentLi = parentUl.parentElement;
         if (!parentLi || parentLi.tagName !== 'LI') {
             break;
         }
-        
+
         // Look for a checkbox specifically in this parent li (not descendants)
         const checkbox = parentLi.querySelector(':scope > .toctree-checkbox');
         if (checkbox) {
             checkbox.checked = true;
         }
-        
+
         // Move up to the next level
         currentLi = parentLi;
     }
     console.log('Expanded path to element and its children');
-} 
+}
 
 function saveScrollPosition() {
     console.log('Saving scroll position...');
@@ -79,8 +78,23 @@ function saveScrollPosition() {
             console.log('No .toc-content element found!');
             return;
         }
-        // Use sessionStorage to persist the scroll position across page loads.
+
+        // Save the container's scroll position
         sessionStorage.setItem('sidebarScrollPosition', scrollableContainer.scrollTop);
+
+        // Also save the destination page's relative position within the viewport if it's visible
+        const links = document.querySelectorAll('.sidebar-tree a.reference');
+        links.forEach(function(link) {
+            const linkUrl = new URL(link.href, window.location.origin);
+            const rect = link.parentElement.getBoundingClientRect();
+            const containerRect = scrollableContainer.getBoundingClientRect();
+            const relativePosition = rect.top - containerRect.top;
+
+            // Save the relative position for each visible page using its pathname as key
+            const key = 'pageRelativePosition_' + linkUrl.pathname;
+            sessionStorage.setItem(key, relativePosition);
+        });
+
         console.log('Saved scroll position to', scrollableContainer.scrollTop);
     } catch (e) {
         console.log('Could not save scroll position:', e);
@@ -101,7 +115,7 @@ function restoreScrollPosition() {
             console.log('No scroll position to restore!');
             return;
         };
-        
+
         // Restore scroll position to the toc-content container
         scrollableContainer.scrollTop = parseInt(savedScrollPosition, 10);
         console.log('Restored scroll position to', parseInt(savedScrollPosition, 10));
@@ -110,17 +124,48 @@ function restoreScrollPosition() {
     }
 }
 
-function scrollToElementIfNotVisible(element) {
+function scrollToElementIfNotVisible(element)
+{
     console.log('Checking if current page is visible...');
     const rect = element.getBoundingClientRect();
     if (rect.top < 0 || rect.top > window.innerHeight) {
         console.log('Current page is not visible, scrolling to show it...');
+
         element.scrollIntoView({
             behavior: 'instant',
             block: 'center'
         });
-        console.log('Scrolled current page into view');
+
+        console.log('Scrolled current page into view, restoring relative position...');
+
+        // Then try to restore the relative position it had on the previous page
+        const parentUrl = window.parent.location.href;
+        const parentUrlObj = new URL(parentUrl);
+        const key = 'pageRelativePosition_' + parentUrlObj.pathname;
+        const savedRelativePosition = sessionStorage.getItem(key);
+
+        if (savedRelativePosition == null) {
+            console.log('No relative position to restore!');
+            return;
+        }
+
+        const scrollableContainer = document.querySelector('.toc-content');
+        if (scrollableContainer == null) {
+            console.log('No scrollable container found!');
+            return;
+        }
+
+        const targetRelativePosition = parseInt(savedRelativePosition, 10);
+        const currentRect = element.getBoundingClientRect();
+        const containerRect = scrollableContainer.getBoundingClientRect();
+        const currentRelativePosition = currentRect.top - containerRect.top;
+
+        // Calculate how much we need to scroll to restore the relative position
+        const adjustment = currentRelativePosition - targetRelativePosition;
+        scrollableContainer.scrollTop += adjustment;
+
+        console.log('Restored relative position of current page to', targetRelativePosition, 'with adjustment of', adjustment);
     } else {
-        console.log('Current page is visible');
+        console.log('Current page is already visible');
     }
 }


### PR DESCRIPTION
Fixes #147 

The scroll bar on ReadTheDocs is supposed to save the scroll bar position and restore it across pages, and it is using `window.savedScrollPosition` to do so.
While this solution was working in my testing before merging it in #132, it does not work in practice now for some reason.

This changes the save/restore logic to use sessionStorage instead, and also saves/restores the exact position of the page in the viewport, so even the case where the exact scrollbar position cannot be reused it still gets restored to the correct position.

The result can be previewed at https://shader-slanggithubio-aidanfnv-wip.readthedocs.io/en/fix-rtd-toc-scrolling-bug/, and I have confirmed that it is definitely working as expected there.