### PR TITLE
Add CI for Jekyll/Pages build

### DIFF
--- a/.github/workflows/jekyll-build-test.yml
+++ b/.github/workflows/jekyll-build-test.yml
@@ -1,0 +1,40 @@
+name: Build Jekyll Site
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Build with Jekyll
+        id: jekyll-build
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: .
+          destination: ./_site
+          future: false
+          build_revision: ${{ github.sha }}
+          verbose: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test build artifacts
+        run: |
+          if [ ! -d "_site" ]; then
+            echo "Jekyll build failed - _site directory not created"
+            exit 1
+          fi
+          
+          if [ ! -f "_site/index.html" ]; then
+            echo "Jekyll build failed - index.html not generated"
+            exit 1
+          fi
+          
+          echo "Jekyll build completed successfully"


### PR DESCRIPTION
Closes #151

This change adds a GitHub action to locally build the Jekyll build used by the website, as a check for pull requests so that we can catch problematic changes before they are merged, such as the issue in `_data\documentation.yaml` merged in https://github.com/shader-slang/shader-slang.github.io/commit/aea352dea3d05275b6c70b0a389ec0bb5d2ec067#diff-53f0703cb98466dd35e2cec77362187aba1f97157789772ccf6b728d213928e0.