### PR TITLE
Ignore all .so files in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ linkcheck_anchors = False
 linkcheck_ignore = [
     r"https://github.com/your-name/.*",
     r"http://claude.ai/code",
-    r"http://[^ ]+\.so.*",
+    r"http://[^\.]+\.so.*",
     r'https://www\.shadertoy\.com/.*',
 ]
 linkcheck_report_timeouts_as_broken = True


### PR DESCRIPTION
This changes the .so file regex patterns in `linkcheck_ignore` to encompass all .so paths, instead of specific .so paths.

The Slang .so libraries have been renamed, so the current regex patterns do not ignore the bad links made from references to them in the docs. Sphinx misinterprets .so filenames as website URLs with the Somalian .so country TLD, which inevitably fail the link check, so those fake links need to be ignored.