### PR TITLE
Render Liquid templates during Sphinx builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,34 @@ def add_orphan_directive(app, docname, source):
         # No frontmatter, add frontmatter with "orphan: true"
         source[0] = '---\norphan: true\n---\n' + content
 
+def render_liquid(app, docname, source):
+    """Render Jekyll-style Liquid templates so Sphinx sees the same output Jekyll does.
+
+    The shared markdown sources are authored for Jekyll, which evaluates Liquid tags
+    like ``{% capture %}`` / ``{{ var | markdownify }}``. MyST passes those through
+    unchanged, so we evaluate them here. The ``markdownify`` filter is a no-op because
+    MyST will parse the captured markdown after this hook runs.
+    """
+    content = source[0]
+    if '{%' not in content and '{{' not in content:
+        return
+
+    try:
+        from liquid import Environment
+    except ImportError:
+        return
+
+    env = Environment()
+    env.add_filter("markdownify", lambda value: value)
+
+    try:
+        source[0] = env.from_string(content).render()
+    except Exception as exc:
+        from sphinx.util import logging as sphinx_logging
+        sphinx_logging.getLogger(__name__).warning(
+            "Liquid rendering failed for %s: %s", docname, exc
+        )
+
 def latex_block_to_inline(app, docname, source):
     content = source[0]
     # Replace $$ with $ for inline math, but only when not part of a block
@@ -109,6 +137,7 @@ def setup(app):
 
     app.connect('source-read', latex_block_to_inline)
     app.connect('source-read', handle_utf16le_files)
+    app.connect('source-read', render_liquid)
 
 project = 'Slang Documentation'
 author = 'Chris Cummings, Benedikt Bitterli, Sai Bangaru, Yong Hei, Aidan Foster'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme==1.3.0rc1
 myst-parser
 furo
 linkify-it-py
+python-liquid


### PR DESCRIPTION
Fixes #189

The migration guide at https://docs.shader-slang.org/en/latest/coming-from-hlsl.html uses Jekyll Liquid tags (`{% capture %}` / `{{ var | markdownify }}`) to embed fenced code blocks inside HTML tables for the side-by-side HLSL vs. Slang comparison. The Sphinx/MyST pipeline does not understand Liquid, so those tags were being passed through unevaluated and rendering as raw text on the docs site instead of formatted code blocks.

This change adds `python-liquid` as a dependency and registers a Sphinx `source-read` hook in `docs/conf.py` that evaluates Liquid templates in markdown sources before MyST sees them. The `markdownify` filter is registered as a no-op since MyST will parse the captured markdown after the hook runs. Files without `{%` or `{{` are skipped, and Liquid render errors are reported as warnings rather than failing the build.

I verified the fix locally with `sphinx-build` against `docs/coming-from-hlsl.md` and confirmed all six side-by-side tables should now render with proper HLSL syntax highlighting on the docs site.
