### PR TITLE
Skip adding orphan directive when page is root

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,12 @@ def handle_utf16le_files(app, docname, source):
             source[0] = content
 
 def add_orphan_directive(app, docname, source):
+    # Never mark the root document as an orphan: it owns the top-level toctree.
+    # This also avoids prepending YAML frontmatter to ``index.rst`` (the only
+    # non-markdown source we process), where it would render as literal text.
+    if docname == app.config.root_doc:
+        return
+
     content = source[0]
     # Check if the document already has "orphan: true"
     if 'orphan: true' in content:


### PR DESCRIPTION
Fixes #192 

This change causes the `add_orphan_directive`  hook to immediately return if the doc is the root doc.
This will avoid adding the orphan directive to the `.rst` index file, which will prevent this directive from appearing on the page. This is typically not an issue because the rest of the pages are `.md` files. It does not make sense for a root doc to be orphaned, as an orphan refers to a non-root TOC tree node that is not attached to the tree.

<img width="1231" height="360" alt="image" src="https://github.com/user-attachments/assets/4fac5c80-1f19-44ec-80f0-37bf421bd90e" />
