### PR TITLE
Add cppreference.com to linkcheck regex patterns

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,14 +208,14 @@ suppress_warnings = ["myst.header", "myst.xref_missing", "myst.xref_ambiguous"]
 
 linkcheck_anchors = False
 linkcheck_ignore = [
-    r"https://github.com/your-name/.*",
-    r"http://claude.ai/code",
-    r"http://[^\.]+\.so.*",
-    r'https://www\.shadertoy\.com/.*',
-    r'https://([a-z]+\.)?khronos\.org/.*',
-    r'https://docs\.vulkan\.org/.*',
+    r"https?://github\.com/your-name/.*",
+    r"https?://claude\.ai/code",
+    r"https?://[^\.]+\.so.*",
+    r'https?://www\.shadertoy\.com/.*',
+    r'https?://([a-z]+\.)?khronos\.org/.*',
+    r'https?://docs\.vulkan\.org/.*',
     r'https?://[^/]+\.py(/.*)?$',
-    r"https?://en.cppreference.com/.*",
+    r"https?://([a-z]+\.)?cppreference\.com/.*",
 ]
 linkcheck_report_timeouts_as_broken = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,7 @@ linkcheck_ignore = [
     r'https://([a-z]+\.)?khronos\.org/.*',
     r'https://docs\.vulkan\.org/.*',
     r'https?://[^/]+\.py(/.*)?$',
+    r"https?://en.cppreference.com/.*",
 ]
 linkcheck_report_timeouts_as_broken = True
 


### PR DESCRIPTION
Adds a regex for [cppreference.com](https://cppreference.com/) to the linkcheck_ignore list so to avoid hitting new 403 Forbidden errors coming from that site, to unblock Sphinx CI.

Also updates the other linkcheck patterns to catch any `http` or `https` variants, and to explicitly match escaped period `\.` to actually match ".", instead of unescaped period `.` which matches any character.