### PR TITLE
Add module-level `user_agent` for Sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,11 +218,12 @@ linkcheck_ignore = [
 ]
 linkcheck_report_timeouts_as_broken = True
 
+user_agent = "Slang-Documentation-Linkcheck/1.0 (+https://github.com/shader-slang/shader-slang.github.io)"
+
 # Configure request headers for authentication
 linkcheck_request_headers = {
     "https://github.com/*": {
         "Authorization": f"token {os.environ.get('GITHUB_TOKEN', '')}",
-        "User-Agent": "Slang-Documentation-Linkcheck/1.0"
     }
 }
 


### PR DESCRIPTION
Adds to the Sphinx config a module-level `user_agent` with an attributable string a site maintainer can pattern-match on in Cloudflare, etc., and removes the redundant `User-Agent` from the github.com-specific header block.

This will fix the Sphinx CI errors in #195 